### PR TITLE
SDK 4.0.2 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Stealthometer CXX)
 
 # Find latest version at https://github.com/OrfeasZ/ZHMModSDK/releases
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
-set(ZHMMODSDK_VER "v4.0.0-rc.3")
+set(ZHMMODSDK_VER "v4.0.2")
 include(cmake/setup-zhmmodsdk.cmake)
 
 # Download CMakeRC resource compiler

--- a/src/Stealthometer.cpp
+++ b/src/Stealthometer.cpp
@@ -21,6 +21,7 @@
 #include <Glacier/EUpdateMode.h>
 #include <Glacier/SGameUpdateEvent.h>
 #include <Glacier/ZActor.h>
+#include <Glacier/ZBehavior.h>
 #include <Glacier/ZDelegate.h>
 #include <Glacier/ZGameLoopManager.h>
 #include <Glacier/ZKnowledge.h>
@@ -45,6 +46,7 @@
 #include <system_error>
 #include <utility>
 #include <Windows.h>
+#include <WinSock2.h>
 
 using namespace std::string_literals;
 


### PR DESCRIPTION
Using Stealthometer v0.6.3 with ZHMModSDK v4.0.2 would make the game crash on startup. 
This PR fixes Stealthometer to work with the latest ZHMModSDK version.

The only thing needed to make it compile successfully after bumping the SDK version in CMakeLists was adding the two includes.

I only did a quick in-game test, so I'm sorry if I missed any additional issues caused by the SDK update.